### PR TITLE
:ambulance: pos_wechat and pos_invoice_pay compatibility

### DIFF
--- a/pos_invoice_pay/__manifest__.py
+++ b/pos_invoice_pay/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Point of Sale",
     "live_test_url": "http://apps.it-projects.info/shop/product/pos-invoice-pay?version=10.0",
     "images": ["images/pos_invoice_pay_main.png"],
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "application": False,
 
     "author": "IT-Projects LLC, Artyom Losev",

--- a/pos_invoice_pay/doc/changelog.rst
+++ b/pos_invoice_pay/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.0.2`
+-------
+
+- **FIX:** Compatibility with pos_wechat
+
 `1.0.1`
 -------
 

--- a/pos_invoice_pay/static/src/js/main.js
+++ b/pos_invoice_pay/static/src/js/main.js
@@ -871,6 +871,8 @@ gui.define_screen({name:'invoices_list', widget: InvoicesWidget});
 
 var InvoicePayment = screens.PaymentScreenWidget.extend({
     template: 'InvoicePaymentScreenWidget',
+    original_payment_screen: false,
+
     get_invoice_residual: function () {
         if (this.pos.selected_invoice) {
             return this.pos.selected_invoice.residual;
@@ -996,8 +998,13 @@ var InvoicePayment = screens.PaymentScreenWidget.extend({
     },
 
     validate_order: function () {
-        if (this.order_is_valid()) {
+        if (this.order_is_valid() && this.pos.selected_invoice && this.pos.selected_invoice.id) {
             this.finalize_validation();
+        } else if (!this.pos.selected_invoice) {
+            this.gui.show_popup('error', {
+                'title': _t('Invoice is not selected'),
+                'body': _t('You can not validate the order.'),
+            });
         }
     },
 

--- a/pos_invoice_pay/static/src/xml/pos.xml
+++ b/pos_invoice_pay/static/src/xml/pos.xml
@@ -86,7 +86,7 @@
     </t>
 
     <t t-name="SaleOrdersWidget">
-        <div class="clientlist-screen screen">
+        <div id="sale_order_list_screen" class="clientlist-screen screen">
             <div class="screen-content">
                 <section class="top-content">
                     <span class='button back'>
@@ -152,7 +152,7 @@
     </t>
 
     <t t-name="InvoicesWidget">
-        <div class="clientlist-screen screen">
+        <div id="invoice_list_screen" class="clientlist-screen screen">
             <div class="screen-content">
                 <section class="top-content">
                     <span class='button back'>
@@ -208,7 +208,7 @@
     </t>
 
     <t t-name="InvoicePaymentScreenWidget">
-        <div class='payment-screen screen'>
+        <div id="invoice_payment_screen" class='payment-screen screen'>
             <div class='screen-content'>
                 <div class='top-content'>
                     <span class='button back'>

--- a/pos_qr_payments/static/src/js/pos_qr_payments.js
+++ b/pos_qr_payments/static/src/js/pos_qr_payments.js
@@ -10,11 +10,16 @@ odoo.define('pos_qr_payments', function(require){
     gui.Gui.prototype.screen_classes.filter(function(el) {
         return el.name === 'payment';
     })[0].widget.include({
+        // add variable to differ original screen from inherited ones. Look pos_invoice_pay
+        original_payment_screen: true,
+
         init: function(parent, options) {
             this._super(parent, options);
-            this.pos.bind('validate_order',function(){
-                this.validate_order();
-            },this);
+            if (this.original_payment_screen) {
+                this.pos.bind('validate_order',function(){
+                    this.validate_order();
+                },this);
+            }
         }
     });
 


### PR DESCRIPTION
Have not reproduced an issue, did according to the code.
This
https://github.com/it-projects-llc/pos-addons/pull/791/files#diff-ad37754e03718874d946c1f4565f88dcR15
invokes validate_order after the trigger for payment screen, invoice payment screen is an extension of  the payment screen